### PR TITLE
Modify dex naming rules to be compatible with GDA multi-dex decompilation

### DIFF
--- a/frida_dexdump/__main__.py
+++ b/frida_dexdump/__main__.py
@@ -99,7 +99,7 @@ class DexDumpApplication(ConsoleApplication):
                     continue
                 self.mds.add(md)
                 bs = fix_header(bs)
-                out_path = os.path.join(self.output, "classes{}.dex".format('%02d' % idx if idx != 1 else ''))
+                out_path = os.path.join(self.output, "classes{}.dex".format('%d' % idx if idx != 1 else ''))
                 with open(out_path, 'wb') as out:
                     out.write(bs)
                 logger.info("[+] DexMd5={}, SavePath={}, DexSize={}"


### PR DESCRIPTION
The rules for GDA to decompile a multi-dex are as follows：

> Create a new directory and move them into the new, and rename them as classes.dex, classes2.dex, classes3.dex, classes4.dex..., and then drag the file classes.dex into GDA for analysis, GDA will automatically be decompiled together. If you have `AndroidManifest.xml and put it into the same directory, GDA automatically performs association analysis.

GDA wiki：https://github.com/charles2gan/GDA-android-reversing-Tool/wiki/GDA-Decompiler-FAQ-Summary#2-how-to-do-the-package-analysis-of-several-dexs-in-one-time-for-dexs-dumped-by-gda-dumper-in-device-memory